### PR TITLE
Add `debug metadata` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,7 @@ dependencies = [
  "homedir",
  "inquire",
  "itertools",
+ "jiff",
  "jwalk",
  "location-macros",
  "lockfile",
@@ -1235,6 +1236,47 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "js-sys"
@@ -1540,6 +1582,15 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"

--- a/packages/hurry/Cargo.toml
+++ b/packages/hurry/Cargo.toml
@@ -57,6 +57,7 @@ colored = {workspace = true }
 location-macros = {workspace = true }
 futures = { workspace = true }
 tempfile = { workspace = true }
+jiff = "0.2.15"
 
 [dev-dependencies]
 async-walkdir.workspace = true

--- a/packages/hurry/src/cmd.rs
+++ b/packages/hurry/src/cmd.rs
@@ -1,2 +1,3 @@
 pub mod cache;
 pub mod cargo;
+pub mod debug;

--- a/packages/hurry/src/cmd/debug.rs
+++ b/packages/hurry/src/cmd/debug.rs
@@ -1,0 +1,11 @@
+use clap::Subcommand;
+
+pub mod metadata;
+
+/// Supported debug subcommands.
+#[derive(Clone, Subcommand)]
+pub enum Command {
+    /// Recursively enumerate all files in the directory and emit the paths
+    /// along with the metadata `hurry` tracks for these files.
+    Metadata(metadata::Options),
+}

--- a/packages/hurry/src/cmd/debug/metadata.rs
+++ b/packages/hurry/src/cmd/debug/metadata.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+
+use async_walkdir::WalkDir;
+use clap::Args;
+use color_eyre::{Result, eyre::Context};
+use colored::Colorize;
+use futures::StreamExt;
+use hurry::fs::Metadata;
+use relative_path::PathExt;
+use tracing::instrument;
+
+/// Options for `debug cargo metadata`
+#[derive(Clone, Args, Debug)]
+pub struct Options {
+    /// The directory to inspect.
+    path: PathBuf,
+}
+
+const SPACE: &str = "  ";
+
+#[instrument]
+pub async fn exec(options: Options) -> Result<()> {
+    let mut walker = WalkDir::new(&options.path);
+    while let Some(entry) = walker.next().await {
+        let entry = entry.context("walk files")?;
+        let path = entry
+            .path()
+            .relative_to(&options.path)
+            .context("make relative path")?;
+
+        let name = entry.file_name();
+        let name = name.to_string_lossy().blue();
+        let indent = SPACE.repeat(path.components().skip(1).count());
+
+        let ft = entry.file_type().await.context("get file type")?;
+        if ft.is_dir() {
+            println!("{indent}{name}/");
+        } else {
+            let metadata = Metadata::from_file(entry.path())
+                .await
+                .context("read metadata")?;
+            println!("{indent}{name} -> {metadata:?}");
+        }
+    }
+
+    Ok(())
+}

--- a/packages/hurry/src/fs.rs
+++ b/packages/hurry/src/fs.rs
@@ -43,6 +43,7 @@ use derive_more::{Debug, Display};
 use filetime::FileTime;
 use fslock::LockFile as FsLockFile;
 use futures::{Stream, TryStreamExt};
+use jiff::Timestamp;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use relative_path::RelativePathBuf;
 use tap::{Pipe, Tap, TapFallible, TryConv};
@@ -486,6 +487,7 @@ pub struct Metadata {
     /// the artifact needs to be rebuilt; since we want to have the system
     /// "fail open" (meahing: we prefer to rebuild more if there is a question
     /// instead of produce bad builds) this is an acceptable fallback.
+    #[debug("{}", Timestamp::try_from(mtime.clone()).map(|t| t.to_string()).unwrap_or_else(|_| format!("{mtime:?}")))]
     pub mtime: SystemTime,
 
     /// Whether the file is executable.

--- a/packages/hurry/src/main.rs
+++ b/packages/hurry/src/main.rs
@@ -44,11 +44,16 @@ enum Command {
     /// Fast `cargo` builds
     #[clap(subcommand)]
     Cargo(cmd::cargo::Command),
+
     // TODO: /// Manage remote authentication
     // Auth,
     /// Manage user cache
     #[clap(subcommand)]
     Cache(cmd::cache::Command),
+
+    /// Debug information
+    #[clap(subcommand)]
+    Debug(cmd::debug::Command),
 }
 
 #[instrument]
@@ -96,6 +101,9 @@ async fn main() -> Result<()> {
         Command::Cargo(cmd) => match cmd {
             cmd::cargo::Command::Build(opts) => cmd::cargo::build::exec(opts).await,
             cmd::cargo::Command::Run(opts) => cmd::cargo::run::exec(opts).await,
+        },
+        Command::Debug(cmd) => match cmd {
+            cmd::debug::Command::Metadata(opts) => cmd::debug::metadata::exec(opts).await,
         },
     };
 


### PR DESCRIPTION
Adds `hurry debug metadata <PATH>` as a command.
This command walks the provided directory recursively and runs `Metadata::from_file` on each and prints them.

The intention here is to support more easily diffing two directories (e.g. the one built by cargo and the one restored by hurry) using a command like:
```shell
diff <(hurry debug metadata target_cargo) <(hurry debug metadata target)
```

Obviously you can substitute your own preferred diffing tool here as well (e.g. `riff`).