### PR TITLE
Add `debug copy` command

### DIFF
--- a/packages/hurry/src/cmd/debug.rs
+++ b/packages/hurry/src/cmd/debug.rs
@@ -1,5 +1,6 @@
 use clap::Subcommand;
 
+pub mod copy;
 pub mod metadata;
 
 /// Supported debug subcommands.
@@ -8,4 +9,7 @@ pub enum Command {
     /// Recursively enumerate all files in the directory and emit the paths
     /// along with the metadata `hurry` tracks for these files.
     Metadata(metadata::Options),
+
+    /// Recursively copy the contents of the source directory to destination.
+    Copy(copy::Options),
 }

--- a/packages/hurry/src/cmd/debug/copy.rs
+++ b/packages/hurry/src/cmd/debug/copy.rs
@@ -1,0 +1,23 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use color_eyre::Result;
+use hurry::fs;
+use tracing::instrument;
+
+/// Options for `debug copy`
+#[derive(Clone, Args, Debug)]
+pub struct Options {
+    /// The source directory.
+    source: PathBuf,
+
+    /// The destination directory.
+    destination: PathBuf,
+}
+
+#[instrument]
+pub async fn exec(options: Options) -> Result<()> {
+    let bytes = fs::copy_dir(options.source, options.destination).await?;
+    println!("copied {bytes} bytes");
+    Ok(())
+}

--- a/packages/hurry/src/cmd/debug/metadata.rs
+++ b/packages/hurry/src/cmd/debug/metadata.rs
@@ -9,7 +9,7 @@ use hurry::fs::Metadata;
 use relative_path::PathExt;
 use tracing::instrument;
 
-/// Options for `debug cargo metadata`
+/// Options for `debug metadata`
 #[derive(Clone, Args, Debug)]
 pub struct Options {
     /// The directory to inspect.

--- a/packages/hurry/src/main.rs
+++ b/packages/hurry/src/main.rs
@@ -104,6 +104,7 @@ async fn main() -> Result<()> {
         },
         Command::Debug(cmd) => match cmd {
             cmd::debug::Command::Metadata(opts) => cmd::debug::metadata::exec(opts).await,
+            cmd::debug::Command::Copy(opts) => cmd::debug::copy::exec(opts).await,
         },
     };
 


### PR DESCRIPTION
Adds `hurry debug copy` as a command, which recursively copies the contents of `source` into `destination` using its internal copying functionality.

```shell
hurry debug copy target target2
copied 21013480 bytes
```