### PR TITLE
Remove abs paths from binary

### DIFF
--- a/packages/hurry/src/bin/hurry/cmd/cargo/build.rs
+++ b/packages/hurry/src/bin/hurry/cmd/cargo/build.rs
@@ -136,6 +136,7 @@ async fn exec_inner(
         //
         // [^1]: https://zameermanji.com/blog/2021/6/17/embedding-a-rust-binary-in-another-rust-binary/
         cargo::invoke_env(
+            workspace,
             "build",
             &options.argv,
             [

--- a/packages/hurry/src/bin/hurry/cmd/cargo/run.rs
+++ b/packages/hurry/src/bin/hurry/cmd/cargo/run.rs
@@ -1,6 +1,6 @@
 use clap::Args;
-use color_eyre::Result;
-use hurry::cargo;
+use color_eyre::{Result, eyre::Context};
+use hurry::cargo::{self, Workspace};
 use tracing::instrument;
 
 /// Options for `cargo run`
@@ -19,5 +19,9 @@ pub struct Options {
 
 #[instrument]
 pub async fn exec(options: Options) -> Result<()> {
-    cargo::invoke("run", options.argv).await
+    let workspace = Workspace::from_argv(&options.argv)
+        .await
+        .context("open workspace")?;
+
+    cargo::invoke(&workspace, "run", options.argv).await
 }


### PR DESCRIPTION
Removes absolute paths from binaries using a combination of:
- `-C strip=debuginfo`, which strips debug info from the binary
- `--remap-path-prefix`, which rewrites various path prefixes:
  - `$HOME` -> `USER_HOME`
  - `$CARGO_HOME` -> `CARGO_HOME`
  - Workspace root -> `WORKSPACE_ROOT`
  - Rustup home -> `RUSTUP_HOME`
- `-Z remap-cwd-prefix=.`, which rewrites abs path prefixes to be relative but is nightly only (so we therefore also provide `RUSTC_BOOTSTRAP=1` to Cargo).

I'm not certain that we want to merge in this state; Slack context here: https://attunehq-workspace.slack.com/archives/C08ALDYV85T/p1758066362199509