### PR TITLE
Benchmarks in CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -187,10 +187,10 @@ jobs:
           echo "| Phase | Duration |" >> $GITHUB_STEP_SUMMARY
           echo "| ----- | -------- |" >> $GITHUB_STEP_SUMMARY
           echo "| Clean build | ${{ needs.clean.outputs.duration }}s |" >> $GITHUB_STEP_SUMMARY
-          echo "| `hurry` cached build | ${{ needs.hurry.outputs.duration }}s |" >> $GITHUB_STEP_SUMMARY
-          echo "| `hurry` (no build artifacts) | ${{ needs.hurry-without-build-artifacts.outputs.duration }}s |" >> $GITHUB_STEP_SUMMARY
-          echo "| `swatinem` cached build | ${{ needs.swatinem.outputs.duration }}s |" >> $GITHUB_STEP_SUMMARY
-          echo "| `sccache` cached build | ${{ needs.sccache.outputs.duration }}s |" >> $GITHUB_STEP_SUMMARY
+          echo "| hurry cached build | ${{ needs.hurry.outputs.duration }}s |" >> $GITHUB_STEP_SUMMARY
+          echo "| hurry (no build artifacts) | ${{ needs.hurry-without-build-artifacts.outputs.duration }}s |" >> $GITHUB_STEP_SUMMARY
+          echo "| swatinem cached build | ${{ needs.swatinem.outputs.duration }}s |" >> $GITHUB_STEP_SUMMARY
+          echo "| sccache cached build | ${{ needs.sccache.outputs.duration }}s |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           CLEAN=${{ needs.clean.outputs.duration }}
@@ -208,9 +208,9 @@ jobs:
 
           echo "### Speedup Analysis" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- `hurry` cached vs clean: **${HURRY_SPEEDUP}x** faster" >> $GITHUB_STEP_SUMMARY
-          echo "- `hurry` (no build artifacts) vs clean: **${HURRY_NO_BUILD_SPEEDUP}x** faster" >> $GITHUB_STEP_SUMMARY
-          echo "- `swatinem` cached vs clean: **${SWATINEM_SPEEDUP}x** faster" >> $GITHUB_STEP_SUMMARY
-          echo "- `sccache` cached vs clean: **${SCCACHE_SPEEDUP}x** faster" >> $GITHUB_STEP_SUMMARY
-          echo "- `hurry` vs `swatinem`: **${HURRY_VS_SWATINEM}x** faster" >> $GITHUB_STEP_SUMMARY
-          echo "- `hurry` vs `sccache`: **${HURRY_VS_SCCACHE}x** faster" >> $GITHUB_STEP_SUMMARY
+          echo "- hurry cached vs clean: **${HURRY_SPEEDUP}x** faster" >> $GITHUB_STEP_SUMMARY
+          echo "- hurry (no build artifacts) vs clean: **${HURRY_NO_BUILD_SPEEDUP}x** faster" >> $GITHUB_STEP_SUMMARY
+          echo "- swatinem cached vs clean: **${SWATINEM_SPEEDUP}x** faster" >> $GITHUB_STEP_SUMMARY
+          echo "- sccache cached vs clean: **${SCCACHE_SPEEDUP}x** faster" >> $GITHUB_STEP_SUMMARY
+          echo "- hurry vs swatinem: **${HURRY_VS_SWATINEM}x** faster" >> $GITHUB_STEP_SUMMARY
+          echo "- hurry vs sccache: **${HURRY_VS_SCCACHE}x** faster" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Adds benchmarks:
- clean build
- `hurry` cached (from previous run)
- `swatinem` cached (from previous run)
- `sccache` cached (from previous run)

Benchmarks are run concurrently and summarized on the overall `Benchmark` job, e.g. [here](https://github.com/attunehq/hurry/actions/runs/18180921321#summary-51756508001):
<img width="1052" height="1256" alt="image" src="https://github.com/user-attachments/assets/11d925bb-e0fe-4381-8ac8-4afba1247e92" />

Discussion thread for reference (for example, "why is hurry slower than swatinem"): https://attunehq-workspace.slack.com/archives/C08ALDYV85T/p1759368456595409

