### PR TITLE
Build script output parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,6 +1399,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "simple_test_case",
  "sqlx",
  "strum",
  "subenum",

--- a/packages/hurry/Cargo.toml
+++ b/packages/hurry/Cargo.toml
@@ -66,5 +66,6 @@ async-walkdir.workspace = true
 divan = { workspace = true }
 jwalk = { workspace = true }
 pretty_assertions = { workspace = true }
+simple_test_case.workspace = true
 test-log = { workspace = true, features = ["trace"] }
 xshell = { workspace = true }

--- a/packages/hurry/src/cargo/fixtures/build_script_output_1.txt
+++ b/packages/hurry/src/cargo/fixtures/build_script_output_1.txt
@@ -1,6 +1,6 @@
 cargo:rustc-cfg=curve25519_dalek_bits="64"
 cargo:rustc-cfg=curve25519_dalek_backend="serial"
-cargo:rustc-env=OUT_DIR=__PROFILE_ROOT__/out
-cargo:rerun-if-changed=__PROFILE_ROOT__/build.rs
+cargo:rustc-env=OUT_DIR=__PROFILE__/out
+cargo:rerun-if-changed=__PROFILE__/build.rs
 cargo:warning=Using serial backend
-OUT_DIR = Some(__PROFILE_ROOT__/out)
+OUT_DIR = Some(__PROFILE__/out)

--- a/packages/hurry/src/cargo/fixtures/build_script_output_2.txt
+++ b/packages/hurry/src/cargo/fixtures/build_script_output_2.txt
@@ -1,9 +1,9 @@
-cargo:rustc-link-search=native=__PROFILE_ROOT__/native
-cargo:rustc-link-search=dependency=__PROFILE_ROOT__/deps
+cargo:rustc-link-search=native=__PROFILE__/native
+cargo:rustc-link-search=dependency=__PROFILE__/deps
 cargo:rustc-link-lib=static=mylib
 cargo:rustc-link-lib=ssl
 cargo:rustc-link-arg=-Wl,-rpath,/custom/path
 cargo:rerun-if-env-changed=PKG_CONFIG_PATH
-cargo:rerun-if-changed=__PROFILE_ROOT__/wrapper.h
+cargo:rerun-if-changed=__PROFILE__/wrapper.h
 cargo:rustc-cfg=has_feature="value"
 cargo:metadata=key=value

--- a/packages/hurry/src/cargo/fixtures/build_script_output_mixed.txt
+++ b/packages/hurry/src/cargo/fixtures/build_script_output_mixed.txt
@@ -1,9 +1,9 @@
 Random diagnostic output
 cargo:rustc-cfg=feature_enabled
 More build script output
-cargo:rerun-if-changed=__PROFILE_ROOT__/src/lib.rs
+cargo:rerun-if-changed=__PROFILE__/src/lib.rs
 cargo:warning=Deprecated feature used
 
-cargo:rustc-link-search=__PROFILE_ROOT__/lib
+cargo:rustc-link-search=__PROFILE__/lib
 cargo:unknown-directive=should_be_preserved
 Final output line

--- a/packages/hurry/src/cargo/fixtures/build_script_output_mixed_styles.txt
+++ b/packages/hurry/src/cargo/fixtures/build_script_output_mixed_styles.txt
@@ -1,0 +1,6 @@
+cargo:rustc-cfg=old_style
+cargo::rustc-cfg=current_style
+cargo:warning=Old style warning
+cargo::warning=Current style warning
+cargo:rustc-link-search=__PROFILE__/old
+cargo::rustc-link-search=__PROFILE__/current


### PR DESCRIPTION
Fills out the rest of the `BuildScriptOutput` type to support all published declarations in Cargo.

We do this so that we can better inspect the output of build script files to use when keying the cache. We _may_ want to tighten this further in the future- for example, I stopped short of making a specific type for features in lines like `cargo:rustc-cfg=feature=\"custom\"` and so on; instead these lines all get parsed as `BuildScriptOutputLine::RustcCfg`. I did this because I think we will, and should, just layer in more specificity as we go.