### PR TITLE
refactor: EnvFilter on `tracing-tree` specifically

### DIFF
--- a/packages/hurry/src/bin/hurry/main.rs
+++ b/packages/hurry/src/bin/hurry/main.rs
@@ -14,7 +14,7 @@ use tap::Pipe;
 use tracing::{instrument, level_filters::LevelFilter};
 use tracing_error::ErrorLayer;
 use tracing_flame::FlameLayer;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::{Layer as _, layer::SubscriberExt, util::SubscriberInitExt};
 use tracing_tree::time::FormatTime;
 
 // Since this is a binary crate, we need to ensure these modules aren't pub
@@ -104,12 +104,12 @@ async fn main() -> Result<()> {
                 WhenColor::Never => layer.with_ansi(false),
                 WhenColor::Auto => layer,
             }
+            .with_filter(
+                tracing_subscriber::EnvFilter::builder()
+                    .with_env_var("HURRY_LOG")
+                    .from_env_lossy(),
+            )
         })
-        .with(
-            tracing_subscriber::EnvFilter::builder()
-                .with_default_directive(LevelFilter::INFO.into())
-                .from_env_lossy(),
-        )
         .with(flame_layer)
         .init();
 


### PR DESCRIPTION
1. Moves env filtering from `RUST_LOG` to `HURRY_LOG` for namespacing in case users separately want to set `RUST_LOG` (e.g. for build scripts).
2. Moves env filtering to specifically be on `tracing-tree`, so it no longer affects flamegraph profiling.
3. Removes default directive, so by default nothing is emitted.

Later, if we want to present actual messages to users (as opposed to printing debug information for ourselves), we can explicitly put together a module that uses `{e,}print{ln,}!` and friends to do this.