### PR TITLE
Add default courier url

### DIFF
--- a/packages/hurry/src/bin/hurry/cmd/cargo/build.rs
+++ b/packages/hurry/src/bin/hurry/cmd/cargo/build.rs
@@ -24,7 +24,11 @@ use url::Url;
 #[derive(Clone, Args, Debug)]
 pub struct Options {
     /// Base URL for the Courier instance.
-    #[arg(long = "hurry-courier-url", env = "HURRY_COURIER_URL", default_value = "https://courier.staging.corp.attunehq.com")]
+    #[arg(
+        long = "hurry-courier-url",
+        env = "HURRY_COURIER_URL",
+        default_value = "https://courier.staging.corp.attunehq.com"
+    )]
     #[debug("{courier_url}")]
     courier_url: Url,
 


### PR DESCRIPTION
Right now it points to the staging instance since that's all we have. when we release a prod env we can update.