### PR TITLE
Actually use compression in the transport layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3749,6 +3749,7 @@ version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
+ "async-compression",
  "base64",
  "bytes",
  "cookie",

--- a/packages/hurry/Cargo.toml
+++ b/packages/hurry/Cargo.toml
@@ -56,7 +56,7 @@ duplicate = { workspace = true }
 paste = { workspace = true }
 parse-display = { workspace = true }
 lazy-regex = { workspace = true, features = ["regex", "std"] }
-reqwest = { workspace = true, features = ["json", "stream", "rustls-tls"] }
+reqwest = { workspace = true, features = ["json", "stream", "rustls-tls", "gzip", "brotli"] }
 tokio-util = { workspace = true, features = ["full"] }
 url = { workspace = true }
 flume = { workspace = true }

--- a/packages/hurry/src/bin/hurry/cmd/cargo/build.rs
+++ b/packages/hurry/src/bin/hurry/cmd/cargo/build.rs
@@ -75,7 +75,7 @@ pub async fn exec(options: Options) -> Result<()> {
         .context("opening workspace")?;
     let profile = args.profile().map(Profile::from).unwrap_or(Profile::Debug);
 
-    let courier = Courier::new(options.courier_url);
+    let courier = Courier::new(options.courier_url).context("create courier client")?;
     courier.ping().await.context("ping courier service")?;
 
     // Open cache.

--- a/packages/hurry/src/cas.rs
+++ b/packages/hurry/src/cas.rs
@@ -23,10 +23,9 @@ impl CourierCas {
 
     /// Create a new instance with the provided base url.
     /// Instantiates a new [`Courier`] instance.
-    pub fn new_client(base: Url) -> Self {
-        Self {
-            client: Courier::new(base),
-        }
+    pub fn new_client(base: Url) -> Result<Self> {
+        let client = Courier::new(base)?;
+        Ok(Self { client })
     }
 
     /// Store the entry in the CAS.

--- a/packages/hurry/src/client.rs
+++ b/packages/hurry/src/client.rs
@@ -39,11 +39,17 @@ pub struct Courier {
 
 impl Courier {
     /// Create a new client with the given base URL.
-    pub fn new(base: Url) -> Self {
-        Self {
+    pub fn new(base: Url) -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .gzip(true)
+            .brotli(true)
+            .build()
+            .context("build http client")?;
+
+        Ok(Self {
             base: Arc::new(base),
-            http: reqwest::Client::new(),
-        }
+            http,
+        })
     }
 
     /// Check that the service is reachable.


### PR DESCRIPTION
It helps if you actually enable transport compression on the client.

Before this, it was sitting at around 30MB/s

<img width="939" height="337" alt="image" src="https://github.com/user-attachments/assets/d7b34671-c33e-4eca-959a-8a209d4d2d6b" />
