### PR TITLE
Install `curl` in courier image for health checks

### DIFF
--- a/docker/courier/Dockerfile
+++ b/docker/courier/Dockerfile
@@ -15,6 +15,7 @@ RUN cargo build --release --bin courier
 
 FROM debian:bookworm-slim AS runtime
 WORKDIR /courier
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /courier/target/release/courier /usr/local/bin
 
 USER 1000:1000


### PR DESCRIPTION
`docker compose` health checks were actually failing due to missing `curl` in the image:
<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/8a76c703-bd63-44ea-bf13-510034c3c651" />


This PR fixes them:
<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/cc66590f-4168-4c5c-91ad-4610ff740fe5" />
