### PR TITLE
Enforce releases only from main branch

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -186,6 +186,12 @@ TAG="v$VERSION"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Check that we're on main branch
+CURRENT_BRANCH="$(git branch --show-current)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+    fail "Releases must be created from the 'main' branch. Currently on: $CURRENT_BRANCH"
+fi
+
 # Check for uncommitted changes
 if [[ "$DRY_RUN" == "false" ]] && ! git diff-index --quiet HEAD --; then
     fail "You have uncommitted changes. Please commit or stash them before releasing."


### PR DESCRIPTION
## Summary

Adds a safety check to the release script to ensure releases are only created from the `main` branch. This guarantees that all release tags point to signed commits.

## Problem

When releases were created from feature branches, the tags pointed to unsigned commits because:
- Feature branch commits created by automated tools (Claude Code) run through bash without a TTY
- 1Password (acting as SSH agent) can't prompt for SSH key approval without a TTY
- Result: unsigned commits on feature branches

## Solution

Added branch check that:
- Verifies current branch is `main` before proceeding
- Fails early with clear error message showing current branch
- Ensures tags always point to signed commits (PR merges or manual commits)

## Why Main Branch Commits Are Always Signed

- **PR merges**: GitHub creates signed merge commits attributed to the user
- **Manual commits**: Terminal operations allow 1Password to prompt for key approval

## Changes

```bash
# Check that we're on main branch
CURRENT_BRANCH="$(git branch --show-current)"
if [[ "$CURRENT_BRANCH" != "main" ]]; then
    fail "Releases must be created from the 'main' branch. Currently on: $CURRENT_BRANCH"
fi
```

## Testing

- ✅ Script now fails if run from feature branch
- ✅ Script succeeds when run from main branch
- ✅ Error message clearly indicates the problem

---

🤖 **This PR description was generated with [Claude Code](https://claude.com/claude-code)**

Co-Authored-By: Claude <noreply@anthropic.com>