### PR TITLE
feat: Add Windows support to TypedPath

### DIFF
--- a/packages/hurry/src/path.rs
+++ b/packages/hurry/src/path.rs
@@ -124,8 +124,9 @@ macro_rules! assert_relative {
             );
 
             // Reject paths starting with separator.
-            // Note: While Windows paths do not naturally start with '/', cross-platform code or user input
-            // may provide such paths. This check is intentionally defensive to catch both cases.
+            // Note: While Windows paths do not naturally start with '/', cross-platform
+            // code or user input may provide such paths. This check is
+            // intentionally defensive to catch both cases.
             assert!(
                 !const_str::starts_with!($path, '/') && !const_str::starts_with!($path, '\\'),
                 "path starts with separator"


### PR DESCRIPTION
## Summary

Enables Windows compilation for the hurry project by removing the platform gate from `TypedPath` and implementing Windows-specific path validation. This is a foundational step toward full Windows support (tracked in #123), addressing the core path abstraction that was completely blocked on Windows.

Closes #130, closes #132, closes #134, closes #135

## Areas of Interest

### No Path Normalization (`path.rs:208-223`)
We explicitly do NOT normalize Windows backslashes to forward slashes. This preserves exact path representations and avoids lossy UTF-8 conversions. Windows handles both separators interchangeably at the OS level, and artifacts aren't shared across platforms anyway.

This does lead to potentially worse cache coherency if for some reason some `hurry` instances create paths with different separators than others, but since we get all our paths from the OS itself I don't see that being a major issue. If it becomes one in the future we can address.

### Windows Path Validation (`path.rs:100-137`)
The `assert_relative!` macro now validates Windows paths at compile-time:
- Rejects drive letters (`C:`, `D:`, etc.)
- Rejects UNC paths (`\\server`, `//server`)
- Rejects paths starting with separators

### Removed `as_bytes()` (`path.rs`)
Deleted the Unix-only `as_bytes()` method since it had zero callers and required different semantics on Windows.

### Leveraging std::path
The existing validators use `Path::is_relative()` and `Path::is_absolute()`, which are already platform-aware in Rust std. No validator logic changes were needed.

## Testing

- ✅ All 103 existing tests pass on Unix
- ⏳ Windows testing planned for followup PR (#137)
- No new tests added in this PR since behavior on Unix is unchanged

## Code Map

- **Core changes**: `packages/hurry/src/path.rs`
  - Removed `#[cfg(not(target_os = "windows"))]` gate from `TypedPath` struct
  - Removed Unix-only `OsStrExt` imports (no longer needed)
  - Updated `assert_relative!` macro with Windows validation
  - Removed unused `as_bytes()` method
  - Added documentation on path normalization policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)