### PR TITLE
Always build `--verbose` in CI

### DIFF
--- a/.github/actions/hurry-dev/action.yml
+++ b/.github/actions/hurry-dev/action.yml
@@ -62,7 +62,7 @@ runs:
         - name: Build hurry binary
           if: steps.check-path.outputs.found != 'true' && steps.check-download.outputs.found != 'true'
           shell: bash
-          run: cargo build --release --package hurry
+          run: cargo build --release --package hurry --verbose
 
         - name: Copy built binary to /tmp/hurry
           if: steps.check-path.outputs.found != 'true' && steps.check-download.outputs.found != 'true'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
             - id: build
               run: |
                   START=$(date +%s)
-                  cargo build
+                  cargo build --verbose
                   END=$(date +%s)
                   DURATION=$((END - START))
                   echo "duration=$DURATION" >> $GITHUB_OUTPUT
@@ -38,7 +38,7 @@ jobs:
             - id: build
               run: |
                   START=$(date +%s)
-                  hurry-dev cargo build
+                  hurry-dev cargo build --verbose
                   END=$(date +%s)
                   DURATION=$((END - START))
                   echo "duration=$DURATION" >> $GITHUB_OUTPUT
@@ -59,7 +59,7 @@ jobs:
             - id: build
               run: |
                   START=$(date +%s)
-                  cargo build
+                  cargo build --verbose
                   END=$(date +%s)
                   DURATION=$((END - START))
                   echo "duration=$DURATION" >> $GITHUB_OUTPUT
@@ -83,7 +83,7 @@ jobs:
                   RUSTC_WRAPPER: sccache
               run: |
                   START=$(date +%s)
-                  cargo build
+                  cargo build --verbose
                   END=$(date +%s)
                   DURATION=$((END - START))
                   echo "duration=$DURATION" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,4 +65,4 @@ jobs:
               run: cargo nextest run -p hurry -p courier
 
             - name: Run full build
-              run: cargo build -p hurry -p courier
+              run: cargo build -p hurry -p courier --verbose


### PR DESCRIPTION
Updates CI to always run `cargo build` with `--verbose` for better debugging.

Context: https://attunehq-workspace.slack.com/archives/C08ALDYV85T/p1761676123573139