### PR TITLE
refactor: Add file size to Metadata

### DIFF
--- a/packages/hurry/src/cargo/cache.rs
+++ b/packages/hurry/src/cargo/cache.rs
@@ -713,6 +713,7 @@ impl CargoCache {
         let metadata = fs::Metadata::builder()
             .mtime(mtime)
             .executable(file.executable)
+            .len(data.len() as u64)
             .build();
         fs::write(path, &data).await?;
         metadata.set_file(path).await?;


### PR DESCRIPTION
This makes it a little easier to distinguish whether files were restored correctly using `hurry debug metadata`.