### PR TITLE
refactor: Per-upload Courier URL in daemon

### DIFF
--- a/packages/hurry/src/bin/hurry/cmd/cargo/build.rs
+++ b/packages/hurry/src/bin/hurry/cmd/cargo/build.rs
@@ -8,13 +8,12 @@ use clap::Args;
 use color_eyre::{Result, eyre::Context};
 use derive_more::Debug;
 use tracing::{debug, info, instrument, warn};
+use url::Url;
 
-use clients::Courier;
 use hurry::{
     cargo::{self, CargoBuildArguments, CargoCache, Profile, Workspace},
     progress::TransferBar,
 };
-use url::Url;
 
 /// Options for `cargo build`.
 //
@@ -94,11 +93,8 @@ pub async fn exec(options: Options) -> Result<()> {
         .context("opening workspace")?;
     let profile = args.profile().map(Profile::from).unwrap_or(Profile::Debug);
 
-    let courier = Courier::new(options.courier_url).context("create courier client")?;
-    courier.ping().await.context("ping courier service")?;
-
     // Open cache.
-    let cache = CargoCache::open(courier, workspace)
+    let cache = CargoCache::open(options.courier_url, workspace)
         .await
         .context("opening cache")?;
 

--- a/packages/hurry/src/bin/hurry/cmd/daemon/start.rs
+++ b/packages/hurry/src/bin/hurry/cmd/daemon/start.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, io::Write, time::UNIX_EPOCH};
 
-use axum::{Json, Router, extract::State, routing::post};
+use axum::{Json, Router, routing::post};
 use clap::Args;
 use clients::{
     Courier,
@@ -118,13 +118,7 @@ pub async fn exec(
     let listener = UnixListener::bind(daemon_paths.socket_path.as_std_path())?;
     info!(addr = ?daemon_paths.socket_path, "server listening");
 
-    let courier = Courier::new(options.courier_url)?;
-    let cas = CourierCas::new(courier.clone());
-    let state = ServerState { cas, courier };
-
-    let cargo = Router::new()
-        .route("/upload", post(upload))
-        .with_state(state);
+    let cargo = Router::new().route("/upload", post(upload));
 
     let app = Router::new()
         .nest("/api/v0/cargo", cargo)
@@ -152,19 +146,11 @@ pub async fn exec(
     Ok(())
 }
 
-#[derive(Debug, Clone)]
-struct ServerState {
-    cas: CourierCas,
-    courier: Courier,
-}
-
-async fn upload(
-    State(state): State<ServerState>,
-    Json(req): Json<daemon::CargoUploadRequest>,
-) -> Json<daemon::CargoUploadResponse> {
-    let state = state.clone();
+async fn upload(Json(req): Json<daemon::CargoUploadRequest>) -> Json<daemon::CargoUploadResponse> {
     tokio::spawn(async move {
         trace!(artifact_plan = ?req.artifact_plan, "artifact plan");
+        let courier = Courier::new(req.courier_url)?;
+        let cas = CourierCas::new(courier.clone());
         let restored_artifacts = HashSet::<_>::from_iter(req.skip_artifacts);
         let restored_objects = HashSet::from_iter(req.skip_objects);
 
@@ -186,7 +172,7 @@ async fn upload(
             let (library_unit_files, artifact_files, bulk_entries) =
                 process_files_for_upload(&req.ws, files_to_save, &restored_objects).await?;
 
-            upload_files_bulk(&state.cas, bulk_entries).await?;
+            upload_files_bulk(&cas, bulk_entries).await?;
 
             let content_hash = calculate_content_hash(library_unit_files)?;
             debug!(?content_hash, "calculated content hash");
@@ -198,7 +184,7 @@ async fn upload(
                 artifact_files,
             );
 
-            state.courier.cargo_cache_save(request).await?;
+            courier.cargo_cache_save(request).await?;
         }
 
         Ok::<(), Error>(())

--- a/packages/hurry/src/cargo/cache.rs
+++ b/packages/hurry/src/cargo/cache.rs
@@ -1,23 +1,3 @@
-use std::{
-    collections::HashMap,
-    env::VarError,
-    fmt::Debug,
-    path::PathBuf,
-    process::Stdio,
-    time::{Duration, UNIX_EPOCH},
-};
-
-use crate::{
-    cargo::{
-        self, BuildPlan, BuildScriptOutput, CargoBuildArguments, CargoCompileMode, DepInfo,
-        Profile, QualifiedPath, RootOutput, RustcMetadata, Workspace,
-    },
-    cas::CourierCas,
-    daemon::{self, DaemonReadyMessage, daemon_is_running, daemon_paths},
-    fs, mk_rel_file,
-    path::{AbsDirPath, AbsFilePath, JoinWith},
-    progress::TransferBar,
-};
 use cargo_metadata::TargetKind;
 use clients::{
     Courier,
@@ -36,10 +16,31 @@ use itertools::Itertools;
 use rayon::prelude::*;
 use scopeguard::defer;
 use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    env::VarError,
+    fmt::Debug,
+    path::PathBuf,
+    process::Stdio,
+    time::{Duration, UNIX_EPOCH},
+};
 use tap::Pipe as _;
 use tokio::{io::AsyncBufReadExt as _, task::JoinSet};
 use tracing::{debug, error, instrument, trace, warn};
+use url::Url;
 use uuid::Uuid;
+
+use crate::{
+    cargo::{
+        self, BuildPlan, BuildScriptOutput, CargoBuildArguments, CargoCompileMode, DepInfo,
+        Profile, QualifiedPath, RootOutput, RustcMetadata, Workspace,
+    },
+    cas::CourierCas,
+    daemon::{self, DaemonReadyMessage, daemon_is_running, daemon_paths},
+    fs, mk_rel_file,
+    path::{AbsDirPath, AbsFilePath, JoinWith},
+    progress::TransferBar,
+};
 
 /// Statistics about cache operations.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
@@ -78,6 +79,7 @@ impl RestoreState {
 
 #[derive(Debug, Clone)]
 pub struct CargoCache {
+    courier_url: Url,
     courier: Courier,
     cas: CourierCas,
     ws: Workspace,
@@ -85,9 +87,16 @@ pub struct CargoCache {
 
 impl CargoCache {
     #[instrument(name = "CargoCache::open")]
-    pub async fn open(courier: Courier, ws: Workspace) -> Result<Self> {
+    pub async fn open(courier_url: Url, ws: Workspace) -> Result<Self> {
+        let courier = Courier::new(courier_url.clone())?;
+        courier.ping().await.context("ping courier service")?;
         let cas = CourierCas::new(courier.clone());
-        Ok(Self { cas, courier, ws })
+        Ok(Self {
+            courier_url,
+            courier,
+            cas,
+            ws,
+        })
     }
 
     /// Get the build plan by running `cargo build --build-plan` with the
@@ -490,6 +499,7 @@ impl CargoCache {
         let response = client
             .post("http://localhost/api/v0/cargo/upload")
             .json(&daemon::CargoUploadRequest {
+                courier_url: self.courier_url.clone(),
                 ws: self.ws.clone(),
                 artifact_plan,
                 skip_artifacts: restored.artifacts.into_iter().collect(),

--- a/packages/hurry/src/cargo/workspace.rs
+++ b/packages/hurry/src/cargo/workspace.rs
@@ -7,9 +7,10 @@ use tap::{Pipe as _, Tap as _, TapFallible as _};
 use tokio::task::spawn_blocking;
 use tracing::{debug, instrument};
 
-use crate::path::{AbsDirPath, TryJoinWith as _};
-
-use super::{CargoBuildArguments, Profile};
+use crate::{
+    cargo::{CargoBuildArguments, Profile},
+    path::{AbsDirPath, TryJoinWith as _},
+};
 
 /// The Cargo workspace of a build.
 ///

--- a/packages/hurry/src/daemon/cargo.rs
+++ b/packages/hurry/src/daemon/cargo.rs
@@ -1,10 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-use crate::cargo::{ArtifactKey, ArtifactPlan, Workspace};
 use clients::courier::v1::Key;
+use url::Url;
+
+use crate::cargo::{ArtifactKey, ArtifactPlan, Workspace};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CargoUploadRequest {
+    pub courier_url: Url,
     pub ws: Workspace,
     pub artifact_plan: ArtifactPlan,
     pub skip_artifacts: Vec<ArtifactKey>,


### PR DESCRIPTION
Courier server URLs are now handed to the daemon as part of the upload.

This trades a small performance penalty (creating a client per-build) to make it easier to test the daemon with a local Courier instance.