### PR TITLE
refactor: diff-tree outside of hurry

### DIFF
--- a/packages/hurry/src/bin/hurry/cmd/debug/metadata.rs
+++ b/packages/hurry/src/bin/hurry/cmd/debug/metadata.rs
@@ -1,8 +1,5 @@
 use clap::Args;
-use color_eyre::{
-    Result,
-    eyre::{Context, eyre},
-};
+use color_eyre::{Result, eyre::Context};
 use colored::Colorize;
 use futures::TryStreamExt;
 use hurry::{
@@ -31,9 +28,7 @@ pub async fn exec(options: Options) -> Result<()> {
 
     for path in files.into_iter().sorted() {
         let rel = path.relative_to(&root)?;
-        let name = rel
-            .to_string()
-            .blue();
+        let name = rel.to_string().blue();
 
         let metadata = Metadata::from_file(&path).await.context("read metadata")?;
         println!("{name} -> {metadata:?}");

--- a/scripts/diff-metatree.sh
+++ b/scripts/diff-metatree.sh
@@ -27,6 +27,10 @@ cargo build
 hurry debug metadata ./target/debug/ > $HURRY_DIR/.scratch/trees/$RUN_ID/cargo-tree.txt
 
 # Upload artifacts to Hurry if needed.
+#
+# TODO: Clear the Hurry remote cache too.
+#
+# TODO: Block until the upload is finished.
 hurry cargo build "$@"
 
 # Do a restore and take a snapshot.


### PR DESCRIPTION
This PR adds a variation of `scripts/diff-tree.sh` that works on projects outside of Hurry.