### PR TITLE
Windows releases

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,6 +21,12 @@ AWS_PROFILE="PowerUserAccess/jess@attunehq.com"
 # 3. MSVC cross-compilation via Wine fails with "command line too long" errors for large projects
 # 4. Hurry is a standalone CLI tool that doesn't need MSVC-specific features or Visual Studio interop
 # 5. MSVC would require building on actual Windows machines or Windows CI runners
+#
+# Windows ARM64 (aarch64-pc-windows-*):
+# Not included because cross doesn't provide Docker images for Windows ARM64 targets, and native
+# cross-compilation requires toolchains not available on macOS/Linux. The Windows ARM64 market is
+# still very small, and users can either build from source or use x64 emulation (which works well
+# on Windows ARM64). If this becomes important, we will need to revisit.
 BUILD_TARGETS=(
     "x86_64-apple-darwin"
     "aarch64-apple-darwin"


### PR DESCRIPTION
Adds windows releases to the release process.

Relates to #151: I don't think we need `msvc` after all even to run on normal hosts according to what I've read.

I plan to merge this then do an alpha release so that I can install it on my Windows machine; if it works we'll close that issue as no longer relevant.