### PR TITLE
refactor: Improve restore tracing

### DIFF
--- a/packages/hurry/src/bin/hurry/cmd/debug/check.rs
+++ b/packages/hurry/src/bin/hurry/cmd/debug/check.rs
@@ -65,6 +65,7 @@ pub async fn exec(options: Options) -> Result<()> {
     let artifact_count = artifact_plan.artifacts.len() as u64;
     let progress = TransferBar::new(artifact_count, "Restoring cache");
     cache.restore(&artifact_plan, &progress).await?;
+    drop(progress);
 
     // Run build with `--message-format=json`.
     let mut argv = options.argv;

--- a/packages/hurry/src/bin/hurry/log.rs
+++ b/packages/hurry/src/bin/hurry/log.rs
@@ -46,7 +46,7 @@ where
                 .with_target(true)
                 .with_thread_ids(true)
                 .with_thread_names(true)
-                .with_span_events(FmtSpan::FULL)
+                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
                 .with_timer(Uptime::default())
                 .with_writer(writer)
                 .pretty();

--- a/packages/hurry/src/cargo/cache.rs
+++ b/packages/hurry/src/cargo/cache.rs
@@ -317,7 +317,11 @@ impl CargoCache {
                     if existing_hash == file.object_key {
                         trace!(?path, "file already exists with correct hash, skipping");
                         continue;
+                    } else {
+                        trace!(expected = %file.object_key, actual = %existing_hash, ?path, "file already exists, but incorrect hash");
                     }
+                } else {
+                    trace!(?path, "file does not exist");
                 }
 
                 files_to_restore


### PR DESCRIPTION
Reduces log noise and adds logging for why restored files are being filtered (or not).

This also fixes a bug where the progress bar on `hurry debug check` would incorrectly print a message at the end of the program.