### PR TITLE
feat: Improve release script with AWS auth check and changelog filtering

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -179,7 +179,7 @@ is_user_facing_commit() {
     fi
 
     # Filter out non-user-facing commit types (conventional commits style)
-    if [[ "$commit_msg" =~ ^(refactor|chore|ci|docs|test|style|build):  ]]; then
+    if [[ "$commit_msg" =~ ^(refactor|chore|ci|docs|test|style|build): ]]; then
         return 1
     fi
 
@@ -205,7 +205,7 @@ is_user_facing_commit() {
            [[ "$file" =~ ^\.github/ ]] || \
            [[ "$file" =~ AGENTS\.md$ ]] || \
            [[ "$file" =~ CLAUDE\.md$ ]] || \
-           [[ "$file" =~ ^scripts/(release|install)\.sh$ ]] || \
+           [[ "$file" =~ ^scripts/release\.sh$ ]] || \
            [[ "$file" =~ ^\.scratch/ ]]; then
             ((internal_count++))
         fi
@@ -249,7 +249,7 @@ EOF
     for tag in "${tags_array[@]}"; do
         local version="${tag#v}"
         # Skip prerelease versions (contain - followed by alpha, beta, rc, etc)
-        if [[ ! "$version" =~ -[a-z] ]]; then
+        if [[ ! "$version" =~ -[a-z][a-z0-9.]* ]]; then
             stable_tags+=("$tag")
         fi
     done
@@ -349,7 +349,9 @@ done
 # Handle changelog-only mode
 if [[ "$GENERATE_CHANGELOG_ONLY" == "true" ]]; then
     TEMP_CHANGELOG=$(mktemp)
-    generate_changelog "$TEMP_CHANGELOG" 2>/dev/null
+    if ! generate_changelog "$TEMP_CHANGELOG" 2>&1; then
+        fail "Failed to generate changelog"
+    fi
     cat "$TEMP_CHANGELOG"
     rm "$TEMP_CHANGELOG"
     exit 0


### PR DESCRIPTION
## Summary

Improves the release script with three key enhancements: early AWS authentication validation to fail fast before expensive builds, intelligent changelog filtering to exclude non-user-facing changes (refactors, CI, internal tooling), and prerelease version consolidation so only stable releases appear in the changelog with all prerelease changes rolled up into the corresponding stable release.

## Areas of Interest

### AWS Authentication Check
- **New function**: [`scripts/release.sh:118-137`](https://github.com/attunehq/hurry/blob/5e0ee64a94d5fe3298c09c801f8340c79c48b052/scripts/release.sh#L118-L137) - `check_aws_auth()` validates credentials using `aws sts get-caller-identity`
- **Smart skipping**: Check is skipped when `--skip-upload` or `--dry-run` flags are used (AWS not needed)
- **Placement**: Called at [`scripts/release.sh:280`](https://github.com/attunehq/hurry/blob/5e0ee64a94d5fe3298c09c801f8340c79c48b052/scripts/release.sh#L280) immediately after requirements check, before any expensive operations

### Changelog Filtering
- **New function**: [`scripts/release.sh:168-221`](https://github.com/attunehq/hurry/blob/5e0ee64a94d5fe3298c09c801f8340c79c48b052/scripts/release.sh#L168-L221) - `is_user_facing_commit()` implements heuristic-based filtering
- **Filter rules**:
  - Explicit markers: `[skip changelog]`, `[internal]` to exclude; `[user-facing]` to include
  - Conventional commit prefixes: excludes `refactor:`, `chore:`, `ci:`, `docs:`, `test:`, `style:`, `build:`
  - Content patterns: filters commits mentioning agent tooling (AGENTS.md, CLAUDE.md, agent guidance)
  - File-based: if ALL changed files are internal (`.agents/`, `.github/`, etc.), commit is excluded
- **Prerelease handling**: [`scripts/release.sh:247-255`](https://github.com/attunehq/hurry/blob/5e0ee64a94d5fe3298c09c801f8340c79c48b052/scripts/release.sh#L247-L255) - Filters tags to only stable releases (no `-alpha`, `-beta`, `-rc`)
- **Commit ranges**: Spans from previous stable to current stable, capturing all intermediate prerelease commits

### New CLI Flag
- **`--generate-changelog`**: [`scripts/release.sh:337-344`](https://github.com/attunehq/hurry/blob/5e0ee64a94d5fe3298c09c801f8340c79c48b052/scripts/release.sh#L337-L344) - Generate and preview changelog without requiring a version or performing a release

## Testing

Manual testing of the changelog generation:
```bash
# Preview the filtered changelog
./scripts/release.sh --generate-changelog

# Verify AWS auth check
./scripts/release.sh 1.0.0 --dry-run  # Should check AWS auth
./scripts/release.sh 1.0.0 --skip-upload  # Should skip AWS auth check
```

Expected behavior:
- Changelog should only show stable releases (0.3.0, 0.2.0, 0.1.0)
- Each stable release should include all changes from intermediate prereleases
- Non-user-facing changes (refactors, CI, agent tooling) should be filtered out
- AWS auth check should fail early with helpful error message if credentials are invalid

## Code Map

- **Release script**: [`scripts/release.sh`](https://github.com/attunehq/hurry/blob/5e0ee64a94d5fe3298c09c801f8340c79c48b052/scripts/release.sh) - All changes in a single file
  - Lines 118-137: AWS authentication check
  - Lines 168-221: User-facing commit filter with heuristics
  - Lines 223-305: Updated changelog generation with stable-only releases
  - Lines 337-344: Changelog-only mode handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)