### PR TITLE
chore: Include cache restore time in benchmark measurements

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,46 +50,48 @@ jobs:
     swatinem:
         runs-on: ubuntu-latest
         outputs:
-            duration: ${{ steps.build.outputs.duration }}
+            duration: ${{ steps.complete.outputs.duration }}
 
         steps:
             - uses: actions/checkout@v4
             - run: |
                   rustup toolchain install stable
                   rustup show
+            - id: build
+              run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT
             - uses: Swatinem/rust-cache@v2
               with:
                   shared-key: benchmark
-            - id: build
+            - run: cargo build --verbose
+            - id: complete
               run: |
-                  START=$(date +%s)
-                  cargo build --verbose
                   END=$(date +%s)
-                  DURATION=$((END - START))
+                  DURATION=$((END - ${{ steps.build.outputs.start }}))
                   echo "duration=$DURATION" >> $GITHUB_OUTPUT
 
     sccache:
         runs-on: ubuntu-latest
         outputs:
-            duration: ${{ steps.build.outputs.duration }}
+            duration: ${{ steps.complete.outputs.duration }}
 
         steps:
             - uses: actions/checkout@v4
             - run: |
                   rustup toolchain install stable
                   rustup show
+            - id: build
+              run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT
             - uses: mozilla-actions/sccache-action@v0.0.9
               with:
                   disable_annotations: true
-            - id: build
-              env:
+            - env:
                   SCCACHE_GHA_ENABLED: "true"
                   RUSTC_WRAPPER: sccache
+              run: cargo build --verbose
+            - id: complete
               run: |
-                  START=$(date +%s)
-                  cargo build --verbose
                   END=$(date +%s)
-                  DURATION=$((END - START))
+                  DURATION=$((END - ${{ steps.build.outputs.start }}))
                   echo "duration=$DURATION" >> $GITHUB_OUTPUT
 
     summary:
@@ -101,6 +103,7 @@ jobs:
             - run: |
                   echo "> [!IMPORTANT]" >> $GITHUB_STEP_SUMMARY
                   echo "> Caches are relative to the last successful benchmark." >> $GITHUB_STEP_SUMMARY
+                  echo "> Times include cache restore/transfer overhead for all solutions." >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "## Build Time Comparison" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

The CI benchmark was providing misleading comparisons by excluding cache restore/transfer time for swatinem and sccache. These solutions were only measuring build time after their cache actions completed, even though network transfer overhead was sometimes nearly as long as the build itself. This PR fixes the timing to capture complete end-to-end time for fair apples-to-apples comparisons across all caching solutions.

## Areas of Interest

- **Timing methodology**: The key change is moving the start time capture to before cache actions run for swatinem and sccache, ensuring their network transfer overhead is included in measurements
- **Fair comparison**: hurry timing remains around just the `hurry-dev cargo build` command (not hurry-dev setup time) because the command itself includes network transfer, matching how other solutions work
- **Two-step timing**: swatinem and sccache jobs now split timing into `build` (captures start) and `complete` (calculates duration) steps to work with GitHub Actions' step-based execution model

## Code Map

- **swatinem job** ([`.github/workflows/benchmark.yml:50-71`](https://github.com/attunehq/hurry/blob/f253641493f5a68addcda37ca1006a18829934a4/.github/workflows/benchmark.yml#L50-L71)): Moved timing start before `Swatinem/rust-cache@v2` action, changed output to `steps.complete.outputs.duration`
- **sccache job** ([`.github/workflows/benchmark.yml:73-96`](https://github.com/attunehq/hurry/blob/f253641493f5a68addcda37ca1006a18829934a4/.github/workflows/benchmark.yml#L73-L96)): Moved timing start before `mozilla-actions/sccache-action@v0.0.9` action, changed output to `steps.complete.outputs.duration`
- **summary step** ([`.github/workflows/benchmark.yml:106`](https://github.com/attunehq/hurry/blob/f253641493f5a68addcda37ca1006a18829934a4/.github/workflows/benchmark.yml#L106)): Added clarifying note that times include cache restore/transfer overhead

🤖 Generated with [Claude Code](https://claude.com/claude-code)