### PR TITLE
chore: Migrate GitHub Actions runners to attune-ubuntu-2404-2

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
     clean:
-        runs-on: ubuntu-latest
+        runs-on: attune-ubuntu-2404-2
         outputs:
             duration: ${{ steps.build.outputs.duration }}
 
@@ -29,7 +29,7 @@ jobs:
                   echo "duration=$DURATION" >> $GITHUB_OUTPUT
 
     hurry:
-        runs-on: ubuntu-latest
+        runs-on: attune-ubuntu-2404-2
         outputs:
             duration: ${{ steps.build.outputs.duration }}
 
@@ -48,7 +48,7 @@ jobs:
                   echo "duration=$DURATION" >> $GITHUB_OUTPUT
 
     swatinem:
-        runs-on: ubuntu-latest
+        runs-on: attune-ubuntu-2404-2
         outputs:
             duration: ${{ steps.complete.outputs.duration }}
 
@@ -70,7 +70,7 @@ jobs:
                   echo "duration=$DURATION" >> $GITHUB_OUTPUT
 
     sccache:
-        runs-on: ubuntu-latest
+        runs-on: attune-ubuntu-2404-2
         outputs:
             duration: ${{ steps.complete.outputs.duration }}
 
@@ -96,7 +96,7 @@ jobs:
 
     summary:
         name: Benchmark
-        runs-on: ubuntu-latest
+        runs-on: attune-ubuntu-2404-2
         needs: [clean, hurry, swatinem, sccache]
 
         steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on: attune-ubuntu-2404-2
     permissions:
       contents: write  # Required for git operations (commit, push)
       pull-requests: write  # Required for creating/updating PRs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ env:
 jobs:
     rust:
         name: Build, check, and test Rust
-        runs-on: ubuntu-latest
+        runs-on: attune-ubuntu-2404-2
 
         services:
             postgres:
@@ -69,7 +69,7 @@ jobs:
 
     hurry-rust:
         name: Build with Hurry and check cache restores
-        runs-on: ubuntu-latest
+        runs-on: attune-ubuntu-2404-2
 
         steps:
             - name: Install Rust


### PR DESCRIPTION
Update all workflow files to use self-hosted attune-ubuntu-2404-2 runners instead of ubuntu-latest. This change affects 8 jobs across 3 workflow files:
- claude.yml (1 job)
- benchmark.yml (5 jobs: clean, hurry, swatinem, sccache, summary)
- pr.yml (2 jobs: rust, hurry-rust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)