### PR TITLE
refactor: Refine path impls

### DIFF
--- a/packages/hurry/src/path.rs
+++ b/packages/hurry/src/path.rs
@@ -700,7 +700,10 @@ pub trait TryJoinWith {
 
     /// Join multiple directories to `self`.
     /// The overall path is checked at the end instead of piece by piece.
-    fn try_join_dirs(&self, dirs: impl IntoIterator<Item = impl AsRef<str>>) -> Result<TypedPath<Self::OutputBase, Dir>>;
+    fn try_join_dirs(
+        &self,
+        dirs: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Result<TypedPath<Self::OutputBase, Dir>>;
 
     /// Join multiple directories, followed by a file, to `self`.
     /// The overall path is checked at the end instead of piece by piece.


### PR DESCRIPTION
1. Add the `Debug` impl from #212.
2. Add "join Rel onto Rel" impls from #212.
3. Add `TryJoinWith` impl for `Rel` from #212.
4. Add `JoinWith` impl for `Rel, SomeType` onto `Abs, SomeType` from #212.
5. Remove nonsensical `Dir` to `File` and vice versa conversions.
6. Reformat comments to line break at 80.