### PR TITLE
chore: Add Nudge rules for format args and use placement

### DIFF
--- a/.nudge/rust-format.yaml
+++ b/.nudge/rust-format.yaml
@@ -1,0 +1,23 @@
+version: 1
+
+rules:
+  - name: inline-format-args
+    description: Use inline arguments in format strings instead of positional args
+    message: |
+      Inline the variable into the format string: format!("{var}") instead of format!("{}", var), then retry.
+    on:
+      - hook: PreToolUse
+        tool: Write
+        file: "**/*.rs"
+        content:
+          # Match any macro with format-string-like first argument: macro!("...{}...", var)
+          # Catches: format!("{}", var), custom_log!("{:?}", var), my_macro!("{} {}", a, b), etc.
+          # Does NOT match: format!("{var}"), expressions like format!("{}", x + 1)
+          - kind: Regex
+            pattern: '!\s*\(\s*"[^"]*\{(?::[^}]*)?\}[^"]*"\s*,\s*[a-z_][a-z0-9_]*\s*[,)]'
+      - hook: PreToolUse
+        tool: Edit
+        file: "**/*.rs"
+        new_content:
+          - kind: Regex
+            pattern: '!\s*\(\s*"[^"]*\{(?::[^}]*)?\}[^"]*"\s*,\s*[a-z_][a-z0-9_]*\s*[,)]'

--- a/.nudge/rust-imports.yaml
+++ b/.nudge/rust-imports.yaml
@@ -1,19 +1,25 @@
 version: 1
 
 rules:
-  - name: no-indented-imports
-    description: Imports must be at file level, not inside functions
+  - name: no-use-inside-functions
+    description: Imports must be at file level, not inside functions or closures
     message: Move this import to the top of the file, then retry.
     on:
       - hook: PreToolUse
         tool: Write
         file: "**/*.rs"
         content:
-          - kind: Regex
-            pattern: '(?m)^[ \t]+use '
+          # Match use declarations inside function/closure bodies
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (block (use_declaration) @use)
       - hook: PreToolUse
         tool: Edit
         file: "**/*.rs"
         new_content:
-          - kind: Regex
-            pattern: '(?m)^[ \t]+use '
+          # Match use declarations inside function/closure bodies
+          - kind: SyntaxTree
+            language: rust
+            query: |
+              (block (use_declaration) @use)


### PR DESCRIPTION
## Summary
- Add `inline-format-args` rule: requires inlining variables into format strings (`format!("{var}")` instead of `format!("{}", var)`)
- Upgrade `no-use-inside-functions` rule from regex to tree-sitter for accurate detection of `use` inside function/closure bodies while allowing module blocks

## Test plan
- [x] Tested `inline-format-args` matches `format!("{}", var)`, `custom_macro!("{:?}", var)`, namespaced macros
- [x] Tested `inline-format-args` passes for already-inlined `format!("{var}")` and expressions
- [x] Tested `no-use-inside-functions` catches `use` in function and closure bodies
- [x] Tested `no-use-inside-functions` allows `use` in `mod tests` blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)