### PR TITLE
Add Nudge rule to block git push on main

### DIFF
--- a/.nudge/git-push.yaml
+++ b/.nudge/git-push.yaml
@@ -1,0 +1,17 @@
+version: 1
+
+rules:
+  - name: block-main-push
+    description: Block git push on main branch
+    message: "`git push` is not allowed on `main`. Create a feature branch first."
+    on:
+      - hook: PreToolUse
+        tool: Bash
+        command:
+          - kind: Regex
+            pattern: "git\\s+push"
+        project_state:
+          - kind: Git
+            branch:
+              - kind: Regex
+                pattern: "^main$"


### PR DESCRIPTION
## Summary
Adds a new Nudge rule that uses the project_state feature to prevent accidental `git push` commands when on the main branch. This leverages the blocking functionality added in attunehq/nudge#10.

## Test plan
- Verify the rule is loaded: `nudge validate` should show `block-main-push` in `.nudge/git-push.yaml`
- Test the rule allows push on feature branches: Switch to a feature branch and verify `git push` is not blocked

The final test can't really be tested on this branch, we'll have to validate after it merges:
- Test the rule blocks push on main: Switch to main branch and attempt `git push` to see the blocking message

🤖 Generated with [Claude Code](https://claude.com/claude-code)