### PR TITLE
fix(ci): Generate image tag once in prepare job for consistency

### DIFF
--- a/.github/workflows/publish-courier.yml
+++ b/.github/workflows/publish-courier.yml
@@ -29,9 +29,31 @@ env:
     ECR_REPOSITORY: courier
 
 jobs:
+    prepare:
+        name: Prepare
+        runs-on: ubuntu-latest
+        outputs:
+            tag: ${{ steps.tag.outputs.tag }}
+        steps:
+            - name: Generate image tag
+              id: tag
+              run: |
+                  if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+                    # For version tags, use the tag name (e.g., v1.2.3)
+                    TAG="${{ github.ref_name }}"
+                  else
+                    # For main branch, use main-YYYYMMDDHHMMSS-SHA format
+                    TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+                    SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+                    TAG="main-${TIMESTAMP}-${SHORT_SHA}"
+                  fi
+                  echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+                  echo "Generated tag: ${TAG}"
+
     build:
         name: Build ${{ matrix.platform }}
         runs-on: ${{ matrix.runner }}
+        needs: prepare
         permissions:
             contents: read
             id-token: write
@@ -60,21 +82,6 @@ jobs:
             - name: Login to Amazon ECR
               uses: aws-actions/amazon-ecr-login@v2
 
-            - name: Generate image tag
-              id: tag
-              run: |
-                  if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-                    # For version tags, use the tag name (e.g., v1.2.3)
-                    TAG="${{ github.ref_name }}"
-                  else
-                    # For main branch, use main-YYYYMMDDHHMMSS-SHA format
-                    TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
-                    SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-                    TAG="main-${TIMESTAMP}-${SHORT_SHA}"
-                  fi
-                  echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-                  echo "Generated tag: ${TAG}"
-
             # Use GHA cache instead of ECR registry cache because the ECR repository
             # has tag immutability enabled, which prevents overwriting cache tags.
             - name: Build and push
@@ -84,14 +91,14 @@ jobs:
                   file: docker/courier/Dockerfile
                   platforms: ${{ matrix.platform }}
                   push: true
-                  tags: ${{ secrets.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.tag.outputs.tag }}-${{ matrix.arch }}
+                  tags: ${{ secrets.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.prepare.outputs.tag }}-${{ matrix.arch }}
                   cache-from: type=gha,scope=${{ matrix.arch }}
                   cache-to: type=gha,scope=${{ matrix.arch }},mode=max
 
     manifest:
         name: Create multi-arch manifest
         runs-on: ubuntu-latest
-        needs: build
+        needs: [prepare, build]
         permissions:
             contents: read
             id-token: write
@@ -106,21 +113,9 @@ jobs:
             - name: Login to Amazon ECR
               uses: aws-actions/amazon-ecr-login@v2
 
-            - name: Generate image tag
-              id: tag
-              run: |
-                  if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-                    TAG="${{ github.ref_name }}"
-                  else
-                    TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
-                    SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-                    TAG="main-${TIMESTAMP}-${SHORT_SHA}"
-                  fi
-                  echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-
             - name: Create and push manifest
               run: |
-                  TAG="${{ steps.tag.outputs.tag }}"
+                  TAG="${{ needs.prepare.outputs.tag }}"
                   REGISTRY="${{ secrets.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}"
 
                   docker manifest create "${REGISTRY}:${TAG}" \


### PR DESCRIPTION
## Summary

Fixes the courier publish manifest job failing due to timestamp mismatch. The build jobs and manifest job were each generating their own timestamps independently, so the manifest job couldn't find the images pushed by the build jobs.

Now a single `prepare` job generates the tag once and all downstream jobs reference it via `needs.prepare.outputs.tag`.

## Areas of Interest

- The prepare job is lightweight (just generates a tag string) so adds minimal overhead
- Both build jobs still run in parallel after prepare completes

## Code Map

- **Workflow**: [`publish-courier.yml:31-51`](https://github.com/attunehq/hurry/blob/bc3936dc6becef323279babec0f2d6b6d27e3501/.github/workflows/publish-courier.yml#L31-L51) - New prepare job that generates the tag once
- **Build job**: [`publish-courier.yml:94`](https://github.com/attunehq/hurry/blob/bc3936dc6becef323279babec0f2d6b6d27e3501/.github/workflows/publish-courier.yml#L94) - Uses `needs.prepare.outputs.tag`
- **Manifest job**: [`publish-courier.yml:101`](https://github.com/attunehq/hurry/blob/bc3936dc6becef323279babec0f2d6b6d27e3501/.github/workflows/publish-courier.yml#L101) - Now depends on both prepare and build

🤖 Generated with [Claude Code](https://claude.com/claude-code)