### PR TITLE
fix(ci): Use imagetools for multi-arch manifest with provenance

### DIFF
--- a/.github/workflows/publish-courier.yml
+++ b/.github/workflows/publish-courier.yml
@@ -104,6 +104,9 @@ jobs:
             id-token: write
 
         steps:
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v4
               with:
@@ -113,13 +116,13 @@ jobs:
             - name: Login to Amazon ECR
               uses: aws-actions/amazon-ecr-login@v2
 
+            # Use imagetools instead of docker manifest because buildx produces
+            # manifest lists with provenance attestations, not plain images.
             - name: Create and push manifest
               run: |
                   TAG="${{ needs.prepare.outputs.tag }}"
                   REGISTRY="${{ secrets.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}"
 
-                  docker manifest create "${REGISTRY}:${TAG}" \
+                  docker buildx imagetools create -t "${REGISTRY}:${TAG}" \
                     "${REGISTRY}:${TAG}-amd64" \
                     "${REGISTRY}:${TAG}-arm64"
-
-                  docker manifest push "${REGISTRY}:${TAG}"


### PR DESCRIPTION
## Summary

Fixes the manifest creation step failing because buildx produces manifest lists with provenance attestations, not plain images. Uses `docker buildx imagetools create` instead of `docker manifest create` which can properly combine manifest lists while preserving provenance.

## Areas of Interest

- Requires `setup-buildx-action` in the manifest job to have access to `docker buildx imagetools`
- Preserves provenance attestations in the final multi-arch image

## Code Map

- **Manifest job**: [`publish-courier.yml:106-128`](https://github.com/attunehq/hurry/blob/54655011/.github/workflows/publish-courier.yml#L106-L128) - Added buildx setup and switched to imagetools

🤖 Generated with [Claude Code](https://claude.com/claude-code)