### PR TITLE
fix(ci): Update workflows to use HURRY_API_TOKEN secret

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,7 +41,7 @@ jobs:
             - uses: ./.github/actions/hurry-dev
             - id: build
               env:
-                  HURRY_API_TOKEN: ${{ secrets.HURRY_COURIER_TOKEN }}
+                  HURRY_API_TOKEN: ${{ secrets.HURRY_API_TOKEN }}
               run: |
                   START=$(date +%s)
                   hurry-dev cargo build --verbose

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -116,13 +116,13 @@ jobs:
 
             - name: Populate cache if needed
               env:
-                  HURRY_API_TOKEN: ${{ secrets.HURRY_COURIER_TOKEN }}
+                  HURRY_API_TOKEN: ${{ secrets.HURRY_API_TOKEN }}
                   SQLX_OFFLINE: true
               run: hurry-dev cargo build --verbose
 
             - name: Check that cache restores are fresh
               env:
-                  HURRY_API_TOKEN: ${{ secrets.HURRY_COURIER_TOKEN }}
+                  HURRY_API_TOKEN: ${{ secrets.HURRY_API_TOKEN }}
                   HURRY_LOG: hurry::cmd::debug::check=info
               run: |
                   cargo clean


### PR DESCRIPTION
## Summary

Updates CI workflows to reference the `HURRY_API_TOKEN` secret instead of `HURRY_COURIER_TOKEN`, aligning with the v0.4.1 release. The default API URL (`https://app.hurry.build`) is already configured in hurry itself.

## Code Map

- **CI**: [`.github/workflows/pr.yml:119`](https://github.com/attunehq/hurry/blob/fb144a44f35d8e497812cdc515c0bc205566eeed/.github/workflows/pr.yml#L119) - Updated secret reference in cache populate step
- **CI**: [`.github/workflows/pr.yml:125`](https://github.com/attunehq/hurry/blob/fb144a44f35d8e497812cdc515c0bc205566eeed/.github/workflows/pr.yml#L125) - Updated secret reference in cache freshness check step  
- **CI**: [`.github/workflows/benchmark.yml:44`](https://github.com/attunehq/hurry/blob/fb144a44f35d8e497812cdc515c0bc205566eeed/.github/workflows/benchmark.yml#L44) - Updated secret reference in hurry benchmark job

🤖 Generated with [Claude Code](https://claude.com/claude-code)