### PR TITLE
fix(ci): Clean target directory before hurry benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,6 +39,8 @@ jobs:
                   rustup toolchain install stable
                   rustup show
             - uses: ./.github/actions/hurry-dev
+            - name: Clean target directory from hurry-dev build
+              run: cargo clean
             - id: build
               env:
                   HURRY_API_TOKEN: ${{ secrets.HURRY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `cargo clean` step after `hurry-dev` installation but before the benchmark runs
- Fixes unfair advantage where hurry benchmark was using local cached artifacts from the `hurry-dev` build step

The `hurry-dev` action uses `Swatinem/rust-cache` to cache the hurry binary build, which populates `target/` with incremental compilation artifacts. When the benchmark then runs `hurry-dev cargo build`, hurry correctly detects nothing to restore (`0 files, 0 B`) because local artifacts already exist—making the benchmark artificially fast.

Evidence from [run 20289114196](https://github.com/attunehq/hurry/actions/runs/20289114196):
```
[0 seconds] [0/590] Restoring cache
[0 seconds] [0/0] Restoring cache (0 files, 0 B at 0 MB/s)
```

Validated in [run 20289740354](https://github.com/attunehq/hurry/actions/runs/20289740354?pr=287#summary-58272313237):
```
[0 seconds] [0/590] Restoring cache
[5 seconds] [438/590] Restoring cache (1738 files, 1.34 GB at 267.40 MB/s)
[6 seconds] [591/590] Restoring cache (2268 files, 2.01 GB at 309.88 MB/s)
```

## Test plan
- [x] Verify benchmark workflow runs successfully
- [x] Confirm hurry cache restore shows actual file counts (not 0/0)
- [x] Compare benchmark results with previous runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)