### PR TITLE
fix(dashboard): Add guidance for new users on invite screen

### DIFF
--- a/packages/dashboard/app/routes/invite.$token.tsx
+++ b/packages/dashboard/app/routes/invite.$token.tsx
@@ -101,6 +101,18 @@ export default function InvitePage() {
                   </div>
                 </div>
 
+                {!signedIn && (
+                  <div className="rounded-xl border border-amber-400/25 bg-amber-400/10 p-4">
+                    <div className="text-sm font-medium text-content-primary">
+                      New to Hurry?
+                    </div>
+                    <div className="mt-1 text-sm text-content-secondary">
+                      You'll need to sign in and complete the onboarding flow first.
+                      After that, come back to this invite link to accept it.
+                    </div>
+                  </div>
+                )}
+
                 <div className="flex gap-2">
                   <Button onClick={accept} disabled={!preview.valid || accepting}>
                     {signedIn ? "Accept invite" : "Sign in to accept"}


### PR DESCRIPTION
## Summary

When new users receive an invite link but have never signed in, clicking "Sign in to accept" redirects them through the standard onboarding flow. After onboarding completes, they end up at the home page instead of back at the invite, leaving them confused about how to actually accept the invitation.

This PR adds a clear informational callout on the invite screen for unauthenticated users explaining they need to complete onboarding first and then return to the invite link.

In the future we will likely add a better overall flow for this.

## Screenshots

### Invite without being logged in

<img width="1840" height="1191" alt="Screenshot 2025-12-17 at 11 26 01 AM" src="https://github.com/user-attachments/assets/6124d3c5-8410-42a1-8aef-295309490293" />

### Invite after being logged in
<img width="1840" height="1191" alt="Screenshot 2025-12-17 at 11 26 23 AM" src="https://github.com/user-attachments/assets/015c7497-9386-405f-b16f-c38df4bc35dc" />



## Areas of Interest

- The callout uses amber/warning styling (`border-amber-400/25 bg-amber-400/10`) to match the existing Badge "warn" tone pattern
- The message explicitly tells users to "come back to this invite link" after completing onboarding

## Code Map

- **Dashboard**: [`packages/dashboard/app/routes/invite.$token.tsx:104-113`](https://github.com/attunehq/hurry/blob/386f916dc5b321784c9e72b8d50185711eb64cdb/packages/dashboard/app/routes/invite.$token.tsx#L104-L113) - Added informational callout for unauthenticated users

🤖 Generated with [Claude Code](https://claude.com/claude-code)