### PR TITLE
script: Add CI timeline visualizer with sparklines

### DIFF
--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -35,6 +35,8 @@ gh auth status
 
 # View history of multiple runs
 ./timeline.py --history <run1> <run2> <run3> --repo owner/repo
+./timeline.py --history --branch main --repo owner/repo
+./timeline.py --history --pr 123 --repo owner/repo
 ```
 
 ## Understanding the Output

--- a/scripts/ci/examples.sh
+++ b/scripts/ci/examples.sh
@@ -48,14 +48,20 @@
 # HISTORY VIEW (MULTIPLE RUNS)
 # =============================================================================
 
-# Track performance across multiple runs
+# Track performance across multiple runs (by run IDs)
 ./timeline.py --history 20359275612 20360289566 20361281298 --repo owner/repo
 
-# Output format:
-# Run ID       | Wall Clock | Build Time | Queue Time | Max Queue | Timeline
-# 20359275612  |     40m28s |       4h0m |        17s |        3s | [################    ]
-# 20360289566  |      37m7s |      3h55m |        20s |        5s | [###############     ]
-# 20361281298  |     56m55s |      3h44m |     44m40s |    22m16s | [....############    ]
+# Track performance for recent runs on a branch (uses --limit, default 10)
+./timeline.py --history --branch main --repo owner/repo
+
+# Track performance for runs on a PR
+./timeline.py --history --pr 123 --repo owner/repo
+
+# Output shows sparklines indicating parallelism over time:
+# Run ID       |    Wall |   Build |   Queue | Activity
+# 20359275612  |  40m28s |    4h0m |     17s | ████████████████████████▇▇▆▅▄▄▄▄▄▄▄▄▃▂▂▂
+# 20360289566  |   37m7s |   3h55m |     20s | ████████████████████████▇▇▆▅▄▄▄▄▄▄▄▄▃▂▂▂
+# 20361281298  |  56m55s |   3h44m |  44m40s | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆██▆▅▄▄▄▄▄▃▃▂▂▂▂▂▂▁▁▁▁▁▁▁▁
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Add Python tool to visualize GitHub Actions workflow runs
- Shows job timelines with queue vs run time using Unicode block characters
- Sparklines display job parallelism over time (`▁▂▃▄▅▆▇█`)
- Unified diff view for comparing before/after runs
- Helps answer: "Why was CI slow?" and "Did caching help?"

## Usage

```bash
# List runs to find run IDs
./scripts/ci/timeline.py --list --pr 123 --repo owner/repo
./scripts/ci/timeline.py --list --branch main --repo owner/repo

# View a single run
./scripts/ci/timeline.py <run_id> --repo owner/repo
./scripts/ci/timeline.py --branch main --repo owner/repo  # most recent

# Compare two runs
./scripts/ci/timeline.py <run1> --diff <run2> --repo owner/repo

# View history of runs
./scripts/ci/timeline.py --history <run1> <run2> <run3> --repo owner/repo
./scripts/ci/timeline.py --history --branch main --repo owner/repo
./scripts/ci/timeline.py --history --pr 123 --repo owner/repo
```

## Example Output

Single run view:
```
Job                                      Timeline                 Queue     Run   Total
----------------------------------------------------------------------------------------
x86_64-apple-darwin                      ░░░░░░░█████████████   22m16s  34m39s  56m55s
aarch64-unknown-linux-gnu                ████████                   2s  24m30s  24m32s
----------------------------------------------------------------------------------------

Activity:   ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆██▆▅▄▄▄▄▄▄▄▃▃▃▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁

Legend: █ running  ░ queued
```

History view:
```
Run ID       |    Wall |   Build |   Queue | Activity
----------------------------------------------------------------------------------------
20359275612  |  40m28s |    4h0m |     17s | ████████████████████████▇▇▆▅▄▄▄▄▄▄▄▄▃▂▂▂
20360289566  |   37m7s |   3h55m |     20s | ████████████████████████▇▇▆▅▄▄▄▄▄▄▄▄▃▂▂▂
20361281298  |  56m55s |   3h44m |  44m40s | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆██▆▅▄▄▄▄▄▃▃▂▂▂▂▂▂▁▁▁▁▁▁▁▁
```

## Test plan

- [x] Test `--list --pr` and `--list --branch`
- [x] Test single run view with run ID and `--branch`
- [x] Test diff mode
- [x] Test history view with run IDs, `--branch`, and `--pr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)