### PR TITLE
Output cross stdout/stderr on error

### DIFF
--- a/packages/hurry/src/cargo/cache/restore.rs
+++ b/packages/hurry/src/cargo/cache/restore.rs
@@ -234,10 +234,10 @@ pub async fn restore_units(
             // invariant that dependencies always have older mtimes than their
             // dependents. Otherwise, units that are skipped may have mtimes
             // that are out of sync with units that are restored.
-            if units_to_skip.contains(unit_hash) {
-                if let Err(err) = unit.touch(&ws, starting_mtime).await {
-                    warn!(?unit_hash, ?err, "could not set mtime for skipped unit");
-                }
+            if units_to_skip.contains(unit_hash)
+                && let Err(err) = unit.touch(&ws, starting_mtime).await
+            {
+                warn!(?unit_hash, ?err, "could not set mtime for skipped unit");
             }
             progress.dec_length(1);
             continue;


### PR DESCRIPTION
When debugging cross, we don't see its stdout/stderr. We need this.