### PR TITLE
chore(ci): Add GitHub Actions workflow for hurry releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,11 +239,20 @@ jobs:
                   PRERELEASE="${{ needs.prepare.outputs.prerelease }}"
                   PUBLISHED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
-                  # Download existing versions.json or create empty one
-                  aws s3 cp "s3://${BUCKET}/releases/versions.json" versions.json 2>/dev/null || echo '{"latest": "", "versions": []}' > versions.json
+                  # Download existing versions.json (fail if S3 error other than file not existing)
+                  if ! aws s3 cp "s3://${BUCKET}/releases/versions.json" versions.json 2>&1; then
+                      # Check if it's a 404 (file doesn't exist yet) vs actual error
+                      if aws s3api head-object --bucket "${BUCKET}" --key "releases/versions.json" 2>&1 | grep -q "Not Found"; then
+                          echo "versions.json doesn't exist yet, creating new one"
+                          echo '{"latest": "", "versions": []}' > versions.json
+                      else
+                          echo "::error::Failed to download versions.json from S3"
+                          exit 1
+                      fi
+                  fi
 
-                  # Build platforms array
-                  PLATFORMS='["x86_64-apple-darwin","aarch64-apple-darwin","x86_64-unknown-linux-gnu","aarch64-unknown-linux-gnu","x86_64-unknown-linux-musl","aarch64-unknown-linux-musl","x86_64-pc-windows-gnu"]'
+                  # Build platforms array dynamically from artifacts
+                  PLATFORMS=$(ls artifacts/*.tar.gz | xargs -n1 basename | sed 's/^hurry-//' | sed 's/\.tar\.gz$//' | jq -R -s -c 'split("\n") | map(select(length > 0))')
 
                   # Update versions.json
                   jq --arg version "$VERSION" \
@@ -273,7 +282,14 @@ jobs:
               if: ${{ !inputs.dry_run && needs.prepare.outputs.prerelease == 'false' }}
               run: |
                   git fetch --tags
-                  ./scripts/release.sh --generate-changelog > CHANGELOG.md
+                  if ! ./scripts/release.sh --generate-changelog > CHANGELOG.md; then
+                      echo "::error::Failed to generate changelog"
+                      exit 1
+                  fi
+                  if [[ ! -s CHANGELOG.md ]]; then
+                      echo "::error::Changelog generation produced empty file"
+                      exit 1
+                  fi
 
             - name: Upload changelog
               if: ${{ !inputs.dry_run && needs.prepare.outputs.prerelease == 'false' }}
@@ -305,7 +321,8 @@ jobs:
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "| Platform | Link |" >> $GITHUB_STEP_SUMMARY
                   echo "| -------- | ---- |" >> $GITHUB_STEP_SUMMARY
-                  for target in x86_64-apple-darwin aarch64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-unknown-linux-musl aarch64-unknown-linux-musl x86_64-pc-windows-gnu; do
+                  for archive in artifacts/*.tar.gz; do
+                    target=$(basename "$archive" .tar.gz | sed 's/^hurry-//')
                     echo "| $target | [hurry-${target}.tar.gz](https://${BUCKET}.s3.amazonaws.com/releases/${TAG}/hurry-${target}.tar.gz) |" >> $GITHUB_STEP_SUMMARY
                   done
                   echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to automate hurry releases to S3, replacing the need to run `scripts/release.sh` locally. The workflow builds binaries for all 7 supported platforms in parallel, generates checksums, and uploads to the `hurry-releases` S3 bucket using OIDC authentication.



## Areas of Interest

**Build matrix strategy:**
- Native builds for macOS (both x64 and ARM via `--target`) and x64 Linux GNU
- Cross-compilation via `cargo cross` for ARM Linux, musl variants, and Windows
- Rationale: Native where possible for speed/reliability, cross for targets without available runners or simpler toolchain setup (Windows MinGW)

**Caching:**
- Native builds use `hurry` itself for caching
- Cross builds use `Swatinem/rust-cache` with per-target cache keys, since hurry does not yet accelerate `cargo cross` commands.

**Dry run mode:**
- Can be triggered manually on any branch with `dry_run: true`
- Uses `git describe --always --tags` for version (same as hurry's build.rs)
- Builds artifacts but skips S3 upload
- Example: https://github.com/attunehq/hurry/actions/runs/20387582372

**AWS authentication:**
- Uses OIDC via `aws-actions/configure-aws-credentials`
- Role ARN stored in `HURRY_RELEASE_ROLE` secret (not hardcoded to avoid exposing account ID)

## Testing

1. Triggered dry run manually: `gh workflow run release.yml --ref jssblck/chore/ci-releases -f dry_run=true`
2. Verified all 7 build jobs complete successfully: https://github.com/attunehq/hurry/actions/runs/20387582372
3. Checked artifacts are uploaded to GitHub Actions
4. Checked that the workflow summary shows checksums

## Code Map

- **Workflow**: [`release.yml`](https://github.com/attunehq/hurry/blob/03e3752f9599b83e6b6f2d18df14c2a8d7692917/.github/workflows/release.yml) - Full release automation with 3 jobs: prepare, build (7 parallel), release

🤖 Generated with [Claude Code](https://claude.com/claude-code)