### PR TITLE
chore(ci): Add macOS code signing and notarization to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,55 @@ jobs:
                   HURRY_API_TOKEN: ${{ secrets.HURRY_API_TOKEN }}
               run: ~/.local/bin/hurry cargo build --target ${{ matrix.target }} --package hurry --release
 
+            - name: Import signing certificate
+              if: runner.os == 'macOS'
+              env:
+                  APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+                  APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+              run: |
+                  echo -n "$APPLE_CERTIFICATE_BASE64" | base64 --decode -o $RUNNER_TEMP/certificate.p12
+                  security create-keychain -p "$APPLE_CERTIFICATE_PASSWORD" $RUNNER_TEMP/build.keychain
+                  security default-keychain -s $RUNNER_TEMP/build.keychain
+                  security unlock-keychain -p "$APPLE_CERTIFICATE_PASSWORD" $RUNNER_TEMP/build.keychain
+                  security import $RUNNER_TEMP/certificate.p12 -k $RUNNER_TEMP/build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+                  security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$APPLE_CERTIFICATE_PASSWORD" $RUNNER_TEMP/build.keychain
+                  rm $RUNNER_TEMP/certificate.p12
+
+            - name: Sign macOS binary
+              if: runner.os == 'macOS'
+              env:
+                  APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+              run: |
+                  codesign --sign "$APPLE_TEAM_ID" \
+                           --timestamp \
+                           --options=runtime \
+                           --force \
+                           target/${{ matrix.target }}/release/hurry
+
+            - name: Store notarization credentials
+              if: runner.os == 'macOS'
+              env:
+                  APPLE_ID: ${{ secrets.APPLE_ID }}
+                  APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+                  APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+              run: |
+                  xcrun notarytool store-credentials "notarytool-password" \
+                          --apple-id "$APPLE_ID" \
+                          --team-id "$APPLE_TEAM_ID" \
+                          --password "$APPLE_APP_SPECIFIC_PASSWORD"
+
+            - name: Submit for notarization
+              if: runner.os == 'macOS'
+              run: |
+                  zip $RUNNER_TEMP/hurry-macos.zip target/${{ matrix.target }}/release/hurry
+                  xcrun notarytool submit $RUNNER_TEMP/hurry-macos.zip \
+                          --keychain-profile "notarytool-password" \
+                          --wait
+
+            - name: Cleanup keychain
+              if: runner.os == 'macOS' && always()
+              run: security delete-keychain $RUNNER_TEMP/build.keychain || true
+
             - name: Package binary
               id: package
               shell: bash


### PR DESCRIPTION
## Summary

macOS binaries are now signed with our Developer ID Application certificate and submitted to Apple's notarization service during the release workflow. This resolves Gatekeeper warnings that users may encounter when installing hurry via the install script.

## Required Secrets

The following secrets must be configured in the repository:

| Secret | Description |
|--------|-------------|
| `APPLE_CERTIFICATE_BASE64` | Base64-encoded .p12 certificate |
| `APPLE_CERTIFICATE_PASSWORD` | Certificate export password |
| `APPLE_TEAM_ID` | Apple Developer Team ID |
| `APPLE_ID` | Apple ID email for notarization |
| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password for notarization |

## Validation

A dry run was performed and both macOS binaries were successfully signed and notarized.

### Fetch binaries from dry run

```bash
cd ~/Downloads
gh run download 20420107265 -R attunehq/hurry --dir hurry-signing-test
tar -xzf hurry-signing-test/hurry-aarch64-apple-darwin/hurry-aarch64-apple-darwin.tar.gz -C hurry-signing-test/
tar -xzf hurry-signing-test/hurry-x86_64-apple-darwin/hurry-x86_64-apple-darwin.tar.gz -C hurry-signing-test/
```

### Compare signing status

**Local (unsigned):**
```bash
codesign -dvv ~/.local/bin/hurry 2>&1 | grep -E '^(Authority|TeamIdentifier|Signature)'
```
```
Signature=adhoc
TeamIdentifier=not set
```

**aarch64 (signed + notarized):**
```bash
codesign -dvv ~/Downloads/hurry-signing-test/hurry-aarch64-apple-darwin/hurry 2>&1 | grep -E '^(Authority|TeamIdentifier|Signature)'
```
```
Signature size=9001
Authority=Developer ID Application: Attune Technologies, Inc. (2675TU77A2)
Authority=Developer ID Certification Authority
Authority=Apple Root CA
TeamIdentifier=2675TU77A2
```

**x86_64 (signed + notarized):**
```bash
codesign -dvv ~/Downloads/hurry-signing-test/hurry-x86_64-apple-darwin/hurry 2>&1 | grep -E '^(Authority|TeamIdentifier|Signature)'
```
```
Signature size=9000
Authority=Developer ID Application: Attune Technologies, Inc. (2675TU77A2)
Authority=Developer ID Certification Authority
Authority=Apple Root CA
TeamIdentifier=2675TU77A2
```

### Summary

| Binary | Signature | TeamIdentifier |
|--------|-----------|----------------|
| Local (current) | adhoc | not set |
| aarch64 (new) | Developer ID Application: Attune Technologies, Inc. | 2675TU77A2 |
| x86_64 (new) | Developer ID Application: Attune Technologies, Inc. | 2675TU77A2 |

### Notarization Confirmation

From the [dry run workflow](https://github.com/attunehq/hurry/actions/runs/20420107265), Apple's notarization service returned `status: Accepted` for both binaries:

[**aarch64-apple-darwin:**](https://github.com/attunehq/hurry/actions/runs/20420107265/job/58670024285#step:12:28):
```
Conducting pre-submission checks for hurry-macos.zip and initiating connection to the Apple notary service...
Submission ID received
  id: 7d50eee3-7608-4f4a-a869-cedee8502f40
Successfully uploaded file
  id: 7d50eee3-7608-4f4a-a869-cedee8502f40
  path: /Users/runner/work/_temp/hurry-macos.zip
Waiting for processing to complete.
Current status: In Progress.......
Current status: Accepted........Processing complete
  id: 7d50eee3-7608-4f4a-a869-cedee8502f40
  status: Accepted
```

[**x86_64-apple-darwin:**](https://github.com/attunehq/hurry/actions/runs/20420107265/job/58670024296#step:12:28)
```
Conducting pre-submission checks for hurry-macos.zip and initiating connection to the Apple notary service...
Submission ID received
  id: 7c106b2f-d2af-4c64-bade-574ceb6feddb
Successfully uploaded file
  id: 7c106b2f-d2af-4c64-bade-574ceb6feddb
  path: /Users/runner/work/_temp/hurry-macos.zip
Waiting for processing to complete.
Current status: In Progress.......
Current status: Accepted........Processing complete
  id: 7c106b2f-d2af-4c64-bade-574ceb6feddb
  status: Accepted
```

## Code Map

- **CI**: [`release.yml:143-190`](https://github.com/attunehq/hurry/blob/d7f120ff4aec8059b3dca03aba65f98f77b1846c/.github/workflows/release.yml#L143-L190) - Added signing, notarization, and keychain cleanup steps for macOS builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)