### PR TITLE
chore: Update install script URLs to use hurry.build domain

### DIFF
--- a/packages/dashboard/app/routes/onboarding.tsx
+++ b/packages/dashboard/app/routes/onboarding.tsx
@@ -160,8 +160,8 @@ function InstallTabs() {
   const [platform, setPlatform] = useState<Platform>(detectPlatform);
 
   const commands = {
-    unix: "curl -sSfL https://hurry-releases.s3.amazonaws.com/install.sh | bash",
-    windows: "irm https://hurry-releases.s3.amazonaws.com/install.ps1 | iex",
+    unix: "curl -sSfL https://hurry.build/install.sh | bash",
+    windows: "irm https://hurry.build/install.ps1 | iex",
   };
 
   return (

--- a/packages/dashboard/app/routes/org.$orgId._index.tsx
+++ b/packages/dashboard/app/routes/org.$orgId._index.tsx
@@ -151,8 +151,8 @@ function GettingStartedInstallTabs() {
   const [platform, setPlatform] = useState<Platform>(detectPlatform);
 
   const commands = {
-    unix: "curl -sSfL https://hurry-releases.s3.amazonaws.com/install.sh | bash",
-    windows: "irm https://hurry-releases.s3.amazonaws.com/install.ps1 | iex",
+    unix: "curl -sSfL https://hurry.build/install.sh | bash",
+    windows: "irm https://hurry.build/install.ps1 | iex",
   };
 
   return (


### PR DESCRIPTION
Replace S3 bucket URLs (hurry-releases.s3.amazonaws.com) with the branded domain (hurry.build) for installation scripts displayed in the onboarding and organization dashboard pages.