### PR TITLE
use `ubuntu-latest` runner for `test` job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,7 +51,7 @@ jobs:
 
     test:
         name: Run tests
-        runs-on: ubuntu-latest-l
+        runs-on: ubuntu-latest
 
         services:
             postgres:


### PR DESCRIPTION
The `ubuntu-latest-l` runner is a GitHub-provided runner, but seems to be stuck on multiple other PRs.

Since we require tests to pass for PRs to merge, moving the `test` job back to `ubuntu-latest` to work around this; I'm leaving the `e2e` workflow using `ubuntu-latest-l` because it literally doesn't work on the normal-sized runner. We can monitor and see if we need to move to a different runner service or something to make it work.